### PR TITLE
Added asynchronous reporting, case-insensitive host checking

### DIFF
--- a/lib/attackMonitoring.js
+++ b/lib/attackMonitoring.js
@@ -1,6 +1,10 @@
 const https = require('https');
 const http = require('http');
 
+// Make local copy of JSON.stringify and setTimeout
+const stringify = JSON.stringify;
+const timeoutSet = setTimeout;
+
 //default state is false.
 let allowOutboundRequest = false;
 let policy;
@@ -121,7 +125,7 @@ function checkOutboundRequest(outBoundReqDomain, reportUri, stack, blockedArray,
             if (allowedModuleDomains.includes(outBoundReqDomain)){
                 for (j=0; j < modulePaths.length; j++){
                     const regex = new RegExp(modulePaths[j]);
-                    if(regex.test(stack)){
+                    if(regex.test(fileLines)){
                         //Outbound Request allowed
                         return true;
                     }
@@ -131,7 +135,7 @@ function checkOutboundRequest(outBoundReqDomain, reportUri, stack, blockedArray,
                     if (wildcardCheck(allowedModuleWildcardDomains[j], outBoundReqDomain)){
                         for (k=0; k < modulePaths.length; k++) {
                             const regex = new RegExp(modulePaths[k]);
-                            if(regex.test(stack)){
+                            if(regex.test(fileLines)){
                                 //Outbound Request allowed
                                 return true;
                             }
@@ -224,7 +228,7 @@ let enableAttackMonitoring = function (appId, policyJSON, callbackFunction) {
 // Send CSP Report.
 function sendReport(violationEvent){
     const url = reportUri;
-    const data = JSON.stringify(violationEvent);
+    const data = stringify(violationEvent);
     const options = {
         method: 'POST',
         headers: {
@@ -272,7 +276,7 @@ let checkSocketConnection = function (args, stack) {
                 cspReport["blocked-uri"] = arg0.protocol + "//" + arg0.host + ":" + arg0.port;
                 cspReport["violated-directive"] = "connect-src";
                 cspReport["effective-directive"] = "connect-src";
-                cspReport["original-policy"] = JSON.stringify(policy);
+                cspReport["original-policy"] = stringify(policy);
                 cspReport["disposition"] = "report";
                 cspReport["status-code"] = 200;
                 cspReport["script-sample"] = "";
@@ -286,7 +290,7 @@ let checkSocketConnection = function (args, stack) {
                 }
                 // If limit has not been reached, send csp report.
                 if (violationLimit - violations >= 0) {
-                    setTimeout(sendReport, 10, violationEvent);
+                    timeoutSet(sendReport, 10, violationEvent);
                 }
             }
         } else {

--- a/lib/attackMonitoring.js
+++ b/lib/attackMonitoring.js
@@ -17,6 +17,7 @@ var violationLimit = 100;
 var violationTime = 0;
 var nssVersion = "";
 var reportUri = "";
+var reportUriIsHttp = false;
 
 function isPureObject(input) {
   return null !== input && typeof input === 'object' && Object.getPrototypeOf(input).isPrototypeOf(Object);
@@ -36,6 +37,24 @@ function wildcardCheck(wildcardDomain, outBoundReqDomain) {
     return false;
 }
 
+function extractHostname(url) {
+  var hostname;
+  //find & remove protocol (http, ftp, etc.) and get hostname
+
+  if (url.indexOf("//") > -1) {
+    hostname = url.split('/')[2];
+  } else {
+    hostname = url.split('/')[0];
+  }
+
+  //find & remove port number
+  hostname = hostname.split(':')[0];
+  //find & remove "?"
+  hostname = hostname.split('?')[0];
+
+  return hostname.toLowerCase();
+}
+
 function checkOutboundRequest(outBoundReqDomain, reportUri, stack, blockedArray, allowedArray, allowedModuleArray){
     //blockedWildcardDomains => array of domains where all sub domains are blocked. (*)
     const blockedWildcardDomains = blockedArray.filter(domain => domain[0] == "*");
@@ -49,7 +68,9 @@ function checkOutboundRequest(outBoundReqDomain, reportUri, stack, blockedArray,
     /**
      * Allow outbound requests to reportUri
      */
-    if (outBoundReqDomain === reportUri.hostname) {
+    outBoundReqDomain = outBoundReqDomain.toLowerCase();
+    const reportUriDomain = extractHostname(reportUri);
+    if (outBoundReqDomain === reportUriDomain) {
         return true
     }
 
@@ -155,11 +176,16 @@ let enableAttackMonitoring = function (appId, policyJSON, callbackFunction) {
          */
         if ("outBoundRequest" in policyJSON) {
             //todo: enable logging for policy file related exceptions
-            const blockedArray = policyJSON.outBoundRequest.blockedDomains.map(e => e.trim());
-            const allowedArray = policyJSON.outBoundRequest.allowedDomains.filter(domain => isString(domain)).map(e => e.trim());
-            const allowedModuleArray = policyJSON.outBoundRequest.allowedDomains.filter(domain => isPureObject(domain));
+            const blockedArray = policyJSON.outBoundRequest.blockedDomains.map(e => e.trim()).map(e => e.toLowerCase());
+            const allowedArray = policyJSON.outBoundRequest.allowedDomains.filter(domain => isString(domain)).map(e => e.trim()).map(e => e.toLowerCase());
+            const allowedModuleArray = policyJSON.outBoundRequest.allowedDomains.filter(domain => isPureObject(domain)).map(function(obj){
+            obj.domains = obj.domains.map(e => e.toLowerCase());
+            return obj;});
             if (policyJSON.hasOwnProperty('reportUri')){
-                reportUri = new URL(policyJSON.reportUri);
+                reportUri = policyJSON.reportUri;
+                if (reportUri.toLowerCase().startsWith("http:")) {
+                    reportUriIsHttp = true;
+                }
                 // Set the violationLimit
                 if (policy.hasOwnProperty('maxViolationsPerMinute')){
                     violationLimit = policy['maxViolationsPerMinute'];
@@ -196,13 +222,10 @@ let enableAttackMonitoring = function (appId, policyJSON, callbackFunction) {
 }
 
 // Send CSP Report.
-function sendReport(reportUri, violationEvent){
+function sendReport(violationEvent){
+    const url = reportUri;
     const data = JSON.stringify(violationEvent);
-    const url = new URL(reportUri);
     const options = {
-        host: url.hostname,
-        port: url.port,
-        path: url.pathname + url.search,
         method: 'POST',
         headers: {
             'Content-Type': 'application/csp-report',
@@ -211,11 +234,15 @@ function sendReport(reportUri, violationEvent){
         },
     };
     // Check if reportUri is http or https.
-    const req = (url.protocol == 'https:' ? https : http).request(options, res => {
-        //console.log(`Sent violation report with status code : ${res.statusCode}`);
-    });
-    req.write(data);
-    req.end();
+    if (reportUriIsHttp) {
+        const req = http.request(url, options);
+        req.write(data);
+        req.end();
+    } else {
+        const req = https.request(url, options);
+        req.write(data);
+        req.end();
+    }
 }
 
 // Reset violations and log if reports were not sent for some violations.
@@ -259,7 +286,7 @@ let checkSocketConnection = function (args, stack) {
                 }
                 // If limit has not been reached, send csp report.
                 if (violationLimit - violations >= 0) {
-                    sendReport(policy['reportUri'], violationEvent);
+                    setTimeout(sendReport(violationEvent), 10);
                 }
             }
         } else {

--- a/lib/attackMonitoring.js
+++ b/lib/attackMonitoring.js
@@ -286,7 +286,7 @@ let checkSocketConnection = function (args, stack) {
                 }
                 // If limit has not been reached, send csp report.
                 if (violationLimit - violations >= 0) {
-                    setTimeout(sendReport(violationEvent), 10);
+                    setTimeout(sendReport, 10, violationEvent);
                 }
             }
         } else {


### PR DESCRIPTION
# Description
- Previously, reports were being sent synchronously which was impacting the latency of the application. With this commit, the `sendReport` function is being passed to `setTimeout` with a 10ms delay. With this, the latency in case of using NodeSecurityShield and not using it is almost identical. Fixes #12 
- The comparison before was being made in case-sensitive manner. With this commit, comparison of reportUri and outBoundReqDomain, checking in blockedArray, allowedArray, allowedModuleArray and checking of protocol of reportUri to send report is done after converting the respective domains to lowercase. Fixes #11 
- Removal of URL constructor. Before, to send the http/https request, pathname, port, hostname were being extracted and specified in `options`. This was unnecessary as the url can be directly passed with http/https module. Also the hostname of `reportUri` was extracted to compare with `outBoundReqDomain` which is now being done with `extractHostname` function.
- Removed the checking of `reportUri` protocol with a global flag (`reportUriIsHttp`) since it will not change during runtime. With this, request will be sent with `http` if it starts with `http:` and with `https` in all other cases.
- Removed `reportUri` as parameter from `sendReport` since it is globally declared.

# Type of Change
- Performance improvement
- Bug fix

# How has this been tested
- It was tested with [vegeta](https://github.com/tsenart/vegeta). Before, sending reports with `setTimeout`, there was a significant latency difference when NodeSecurityShield was not being used and when it was being used (with the reporting function). After using `setTimeout`, latency in both of them are almost identical.