### PR TITLE
Removed unnecessary variable declaration

### DIFF
--- a/lib/attackMonitoring.js
+++ b/lib/attackMonitoring.js
@@ -12,8 +12,6 @@ let cbFunction;
 let app;
 let attackMonitoring = false; // Default, not enabled.
 let iscbFunctionDefined = false; //Default, not defined. When true, can change cbFUnction at runtime.
-let cbFuncitonLine = "at TLSSocket.obj.<computed> [as connect] (/mnt/c/Ironwasp/Product/NodeSecurityShield/lib/hook.js:22:13)"
-//Error.stackTraceLimit = 60
 var reportUriHosts = [];
 var violations = 0;
 //default violationLimit is 100.


### PR DESCRIPTION
There was a variable declared in `attackMonitoring.js` file but was never used. I have removed it along with an unnecessary comment in the following line.

Fixes #8 