### PR TITLE
Added check if reportUri is not set and fixed typo

### DIFF
--- a/lib/attackMonitoring.js
+++ b/lib/attackMonitoring.js
@@ -247,10 +247,12 @@ function sendReport(violationEvent){
     }
 }
 
-// Reset violations and log if reports were not sent for some violations.
-function violationReset(){
-    if (violations > violationLimit) {
-        console.log(violations - violationLimit + " more violations occured but details not captured.");
+// Reset violations and log if reports were not sent for some violations (only if reportUri has been set).
+function violationReset() {
+    if (reportUri !== "") {
+        if (violations > violationLimit) {
+            console.log(violations - violationLimit + " more violations occured but details not captured.");
+        }
     }
     violationTime = 0;
     violations = 0;
@@ -286,9 +288,11 @@ let checkSocketConnection = function (args, stack) {
                 if (violations === 1) {
                     violationTime = new Date().getTime();
                 }
-                // If limit has not been reached, send csp report.
-                if (violationLimit - violations >= 0) {
-                    timeoutSet(sendReport, 10, violationEvent);
+                // If reportUri has been set and limit has not been reached, send csp report.
+                if (reportUri !== "") {
+                    if (violationLimit - violations >= 0) {
+                        timeoutSet(sendReport, 10, violationEvent);
+                    }
                 }
             }
         } else {

--- a/lib/attackMonitoring.js
+++ b/lib/attackMonitoring.js
@@ -251,7 +251,7 @@ function sendReport(violationEvent){
 function violationReset() {
     if (reportUri !== "") {
         if (violations > violationLimit) {
-            console.log(violations - violationLimit + " more violations occured but details not captured.");
+            console.log(violations - violationLimit + " more violations occurred but details not captured.");
         }
     }
     violationTime = 0;


### PR DESCRIPTION
# Description
- If the `reportUri` is not specified, even then the number of reports that were not sent (i.e. all reports) are said to be not captured which is unnecessary as the user has not specified `reportUri` and it is understood that no reports will be sent. A check has been implemented to check if reportUri is empty before logging the message. Fixes #15 .
- Before, `sendReport` was passed to `setTimeout` even if the `reportUri` is not present. This has been changed so that it is only called if `reportUri` is set by the user.
- There was a typo in the message that was logged if there were more violations than the amount of reports sent. It has been fixed by changing from `occured` to `occurred`.

# Type of change
- Bug fix