### PR TITLE
Added command execution monitoring logic

### DIFF
--- a/lib/attackMonitoring.js
+++ b/lib/attackMonitoring.js
@@ -7,6 +7,7 @@ const timeoutSet = setTimeout;
 
 //default state is false.
 let allowOutboundRequest = false;
+let allowCommand = false;
 let policy;
 let cbFunction;
 let app;
@@ -16,6 +17,7 @@ var violations = 0;
 var violationLimitPerMin = 100;
 //default is false, is true when violations > violationLimitPerMin
 var violationLimitPerMinReached = false;
+var violationType;
 var nssVersion;
 var reportUri;
 var reportUriDomain;
@@ -153,41 +155,51 @@ function checkOutboundRequest(outBoundReqDomain, stack, blockedArray, allowedArr
     return false;
 }
 
+function checkExecutedCommand(command, allowedCommands) {
+    for (i = 0; i < allowedCommands.length; i++) {
+        const regex = new RegExp(allowedCommands[i]);
+        if(regex.test(command)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /**
  * callbackFunction for handling RAP violations
- * 
+ *
  * @callback callbackFunction
- * @param {JSON} violationEvent RAP violation which occurred. It is presented as a CSP violation. 
+ * @param {JSON} violationEvent RAP violation which occurred. It is presented as a CSP violation.
  * @param {Number} violations  RAP violation count. Resets to ZERO every minute.
  * @param {Boolean} violationLimitPerMinReached true if RAP violations count exceeds 'maxViolationsPerMinute'
- * 
+ *
  */
 
 /**
  * For outBoundRequest  , blockedDomains have greater presidence over allowedDomains.
  * i.e., requests are checked against blockedDomains first then allowedDoamins.
  *
- * @param {String} appId A unique identifier for this instance of NSS 
- * @param {Object} policyJSON Resource Access Policy as a JSON 
+ * @param {String} appId A unique identifier for this instance of NSS
+ * @param {Object} policyJSON Resource Access Policy as a JSON
  * @param {callbackFunction} callbackFunction - callbackFunction that handles RAP violations
  */
 let enableAttackMonitoring = function (appId, policyJSON, callbackFunction) {
     /**
-     * Set appId. Changing it requires a server/application restart. 
+     * Set appId. Changing it requires a server/application restart.
      */
     if (typeof app === 'undefined') {
-        app = appId;    
+        app = appId;
     }
-    
+
     /**
-     * Set Resource Access Policy. Changing it requires a server/application restart. 
+     * Set Resource Access Policy. Changing it requires a server/application restart.
      */
     if (typeof policy === 'undefined') {
         policy = policyJSON;
     }
-    
+
     /**
-     * Set callbackFunction. Changing it requires a server/application restart. 
+     * Set callbackFunction. Changing it requires a server/application restart.
      */
     if (typeof cbFunction === 'undefined') {
         cbFunction = callbackFunction;
@@ -203,57 +215,81 @@ let enableAttackMonitoring = function (appId, policyJSON, callbackFunction) {
          * If exists and contains entries,
          * then enable Attack Monitoring for all outbound requests.
          */
-        if ("outBoundRequest" in policyJSON) {
-            //todo: enable logging for policy file related exceptions
-            const blockedArray = policyJSON.outBoundRequest.blockedDomains.map(e => e.trim()).map(e => e.toLowerCase());
-            const allowedArray = policyJSON.outBoundRequest.allowedDomains.filter(domain => isString(domain)).map(e => e.trim()).map(e => e.toLowerCase());
-            const allowedModuleArray = policyJSON.outBoundRequest.allowedDomains.filter(domain => isPureObject(domain)).map(function(obj){
-            obj.domains = obj.domains.map(e => e.toLowerCase());
-            return obj;});
 
-            // check and set reportUri
-            if (policyJSON.hasOwnProperty('reportUri')){
-                if (isString(policyJSON.reportUri)){
-                    reportUri = policyJSON.reportUri;
-                    reportUriDomain = extractHostname(reportUri);
-                    if (reportUri.toLowerCase().startsWith("http:")) { // its http
-                        reportUriIsHttp = true;
-                    }
-                    
-                    // check and set the violationLimitPerMin
-                    if (policyJSON.hasOwnProperty('maxViolationsPerMinute')){
-                        if (typeof policyJSON['maxViolationsPerMinute'] === 'number') {
-                            violationLimitPerMin = policyJSON['maxViolationsPerMinute'];    
-                        }else{
-                           // todo: log - RAP's  maxViolationsPerMinute value is expected to be a number
-                        }
+         // check and set reportUri
+         if (policyJSON.hasOwnProperty('reportUri')){
+             if (isString(policyJSON.reportUri)){
+                 reportUri = policyJSON.reportUri;
+                 reportUriDomain = extractHostname(reportUri);
+                 if (reportUri.toLowerCase().startsWith("http:")) { // its http
+                     reportUriIsHttp = true;
+                 }
+
+                 // check and set the violationLimitPerMin
+                 if (policyJSON.hasOwnProperty('maxViolationsPerMinute')){
+                     if (typeof policyJSON['maxViolationsPerMinute'] === 'number') {
+                         violationLimitPerMin = policyJSON['maxViolationsPerMinute'];
+                     }else{
+                        // todo: log - RAP's  maxViolationsPerMinute value is expected to be a number
+                     }
+                 }
+
+                 // Reset the violations count every minute.
+                 setInterval(violationReset, 60000);
+             }else{
+                 // todo: log - RAP's reportUri value is expected to be a string
+             }
+         }
+
+        // Check if any valid property for attackMonitoring is present in policyJSON.
+        if (policyJSON.hasOwnProperty('outBoundRequest') || policyJSON.hasOwnProperty('executedCommand')) {
+
+            var totalLength = 0;
+            if ("outBoundRequest" in policyJSON) {
+                //todo: enable logging for policy file related exceptions
+                const blockedArray = policyJSON.outBoundRequest.blockedDomains.map(e => e.trim()).map(e => e.toLowerCase());
+                const allowedArray = policyJSON.outBoundRequest.allowedDomains.filter(domain => isString(domain)).map(e => e.trim()).map(e => e.toLowerCase());
+                const allowedModuleArray = policyJSON.outBoundRequest.allowedDomains.filter(domain => isPureObject(domain)).map(function(obj){
+                obj.domains = obj.domains.map(e => e.toLowerCase());
+                return obj;});
+
+                if ((blockedArray.length + allowedArray.length + allowedModuleArray.length) > 0) {
+                    totalLength += blockedArray.length + allowedArray.length + allowedModuleArray.length;
+                    allowOutboundRequest = (outBoundReqDomain, stack) => {
+                        // Check outBoundReqDomain.
+                        return checkOutboundRequest(outBoundReqDomain, stack, blockedArray, allowedArray, allowedModuleArray);
                     }
 
-                    // Reset the violations count every minute.
-                    setInterval(violationReset, 60000);
-                }else{
-                    // todo: log - RAP's reportUri value is expected to be a string 
+                }
+
+            }
+
+            if ("executedCommand" in policyJSON) {
+                const allowedCommandsArray = policyJSON.executedCommand.allowedCommands.map(e => e.trim()).map(e => e.toLowerCase());
+
+                if (allowedCommandsArray.length > 0) {
+                    totalLength += allowedCommandsArray.length;
+                    allowCommand = (executedCommand) => {
+                        // Check executedCommand.
+                        return checkExecutedCommand(executedCommand, allowedCommandsArray);
+                    }
                 }
             }
 
-            // attackMonitoring is enabled only if there are entries in blockedDomain or allowedDomains
-            if ((blockedArray.length + allowedArray.length) > 0) {
-
+            // attackMonitoring is enabled only if there are any valid entries
+            if (totalLength > 0) {
                 //Enable attackMonitoring
                 attackMonitoring = true;
                 console.log('NSS : Attack Monitoring enabled. ');
 
                 //Get NodeSecurityShield Version
                 nssVersion = require('../package.json').version;
-
-                allowOutboundRequest = (outBoundReqDomain, stack) => {
-                    // Check outBoundReqDomain.
-                    return checkOutboundRequest(outBoundReqDomain, stack, blockedArray, allowedArray, allowedModuleArray);
-                }
-
             }
 
         }
+
+
+
 
     }
 
@@ -288,6 +324,35 @@ function violationReset() {
     violations = 0;
 }
 
+// Prepare CSP Report according to eventType.
+function prepareReport(args, eventType, stack) {
+    let cspReport = {};
+    let blockedParam;
+    let directive;
+    let scriptSample = "";
+    switch (eventType) {
+        case 'socket':
+            directive = "connect-src";
+            blockedParam = args.protocol + "//" + args.host + ":" + args.port;
+            break;
+        case 'command':
+            directive = "script-src";
+            blockedParam = "https://command-execution";
+            scriptSample = args.join(' ');
+            break;
+    }
+    cspReport["document-uri"] = "https://"+app;
+    cspReport["blocked-uri"] = blockedParam;
+    cspReport["violated-directive"] = directive;
+    cspReport["effective-directive"] = directive;
+    cspReport["original-policy"] = stringify(policy);
+    cspReport["disposition"] = "report";
+    cspReport["status-code"] = 200;
+    cspReport["script-sample"] = scriptSample;
+    cspReport["source-file"] = stack;
+    return cspReport;
+}
+
 let checkSocketConnection = function (args, stack) {
 
     let arg0;
@@ -301,26 +366,15 @@ let checkSocketConnection = function (args, stack) {
             if (!allowOutboundRequest(arg0.host, stack)) {
                 violations++;
                 let violationEvent = {};
-                let cspReport = {};
-                cspReport["document-uri"] = "https://"+app;
-                cspReport["blocked-uri"] = arg0.protocol + "//" + arg0.host + ":" + arg0.port;
-                cspReport["violated-directive"] = "connect-src";
-                cspReport["effective-directive"] = "connect-src";
-                cspReport["original-policy"] = stringify(policy);
-                cspReport["disposition"] = "report";
-                cspReport["status-code"] = 200;
-                cspReport["script-sample"] = "";
-                cspReport["source-file"] = stack;
-                violationEvent["csp-report"] = cspReport;
-                
-                
+                violationEvent["csp-report"] = prepareReport(arg0, "socket", stack);
+
                 // If reportUri has been set and limit has not been reached, send csp report.
                 if ( typeof reportUri === 'string') {
                     if (violationLimitPerMin - violations >= 0) {
                         timeoutSet(sendReport, 10, violationEvent);
                     }
                 }
-                
+
                 cbFunction(violationEvent, violations, violationLimitPerMinReached);
             }
         } else {
@@ -331,6 +385,23 @@ let checkSocketConnection = function (args, stack) {
     }
 }
 
+let checkCommandExecution = function(args, stack) {
+    let arg0;
+    arg0 = args['0'].args;
+    var executedCommand = args['0'].args.join(' ');
+    if (!allowCommand(executedCommand)) {
+        violations++;
+        let violationEvent = {};
+        violationEvent["csp-report"] = prepareReport(arg0, 'command', stack);
+        if (typeof reportUri === 'string') {
+            if (violationLimitPerMin - violations >= 0) {
+                timeoutSet(sendReport, 10, violationEvent);
+            }
+        }
+        cbFunction(violationEvent, violations, violationLimitPerMinReached);
+    }
+}
+
 let resourceAccessPolicyCheck = function (eventType, args, stack) {
     //Check if attackMonitoring is enabled.
     if (attackMonitoring) {
@@ -338,10 +409,8 @@ let resourceAccessPolicyCheck = function (eventType, args, stack) {
             case 'socket':
                 checkSocketConnection(args, stack);
                 break;
-            
             case 'command':
-                //checkCommands
-                console.log(args[0]['args'])
+                checkCommandExecution(args, stack);
                 break;
         }
     } else {

--- a/lib/attackMonitoring.js
+++ b/lib/attackMonitoring.js
@@ -17,7 +17,6 @@ var violations = 0;
 var violationLimitPerMin = 100;
 //default is false, is true when violations > violationLimitPerMin
 var violationLimitPerMinReached = false;
-var violationType;
 var nssVersion;
 var reportUri;
 var reportUriDomain;

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -3,7 +3,6 @@ let resourceAccessPolicyCheck = require('./attackMonitoring').resourceAccessPoli
 let isHooked =  false;
 
 let initHooks = function(){
-    //console.log('Initilizing Node Security Shield Hooks')
     if(!isHooked){
         isHooked = true;
         hookSocket();


### PR DESCRIPTION
# Description
- The ability to monitor command execution has been added.
- Changes have been done to `lib/attackMonitoring.js` which will now allow the user to define which commands can be allowed to be executed by the node application.
- Sample `resourceAccessPolicy` :
```js
const resourceAccessPolicy = {
	"outBoundRequest" : {
		"blockedDomains" : ["STATS.abc.com", "xyz.com", "abce.xyz", "*.abce.com"],
		"allowedDomains" : ["*.DOMDOG.io", "abcd.xyz", "ptsv2.com",
			{
				"domains": [
					"abce123.com",
				],
				"modules": [
					{
						"file": "\/node_modules\/axios\/",
					},
				]
			},
		]
  },
	"executedCommand" : {
	    "allowedCommands" : ["du -lah$", "date1.*"]
   },
	"reportUri": "https://abcd.ingest.sentry.io",
	"maxViolationsPerMinute": 7
}
```
- To define commands, user can add a new regex entry in `allowedCommands` array as shown above.
- With the above entry, commands like `du -lah`, `date123` can be executed without violations whereas `du -lahbcd` and `date` will cause violations.
- If in a minute, network and command violations both are triggered, both of them will add to the count.
- The violation report looks like this : 
![image](https://user-images.githubusercontent.com/64483930/188270408-d27ca49b-08cf-4687-b9e5-39e1e4d6ca50.png)
- The directive will be `script-src`, the violated command will be in `script-sample` and the `blocked-uri` will contain `https://command-execution`.


# Type of Change
- New feature